### PR TITLE
Add "--reverse-relationships" option

### DIFF
--- a/src/command/typeorm-uml.class.ts
+++ b/src/command/typeorm-uml.class.ts
@@ -75,6 +75,10 @@ class TypeormUmlCommand extends Command {
 			description: 'Whether or not to show possible values for the enum type field.',
 			default: false,
 		} ),
+		'reverse-relationships': flags.boolean( {
+			description: 'Whether or not to reverse relationship descriptions. (ex: "A ||--|{ B" to "B }|--|| A")',
+			default: false,
+		} ),
 		'plantuml-url': flags.string( {
 			description: 'URL of the plantuml server to use.',
 			default: 'http://www.plantuml.com/plantuml',

--- a/src/types/flags.interface.ts
+++ b/src/types/flags.interface.ts
@@ -17,4 +17,5 @@ export interface Flags {
 	['with-entity-names-only']?: boolean,
 	['with-table-names-only']?: boolean,
 	['with-enum-values']?: boolean,
+	['reverse-relationships']?: boolean,
 }

--- a/src/types/relationship.interface.ts
+++ b/src/types/relationship.interface.ts
@@ -1,0 +1,16 @@
+/**
+ * Left-side based Connector enum/string.
+ */
+export enum RelationshipConnector {
+	ONE = '||',
+	ZERO_OR_ONE = '|o',
+	ZERO_OR_MORE = '}o',
+	ONE_OR_MORE = '}|',
+}
+
+export interface Relationship {
+	leftEntity: string;
+	leftConnector: RelationshipConnector;
+	rightConnector: RelationshipConnector;
+	rightEntity: string;
+}


### PR DESCRIPTION
Hi @eugene-manuilov !

`typeorm-uml` is very useful package. 👍👍👍

In my usecase, there are two entities Parent and Child, and they have `Parent ||--o{ Child` relationship.
The Parent has no TypeORM Relation Decorators definition and it's only written in Child entity.
Because TypeORM requires reference filed like `children: Child[]` for Relation Decorators such as `@OneToMany()`,
but I don't need it everywhere.

In this situation, `typeorm-uml` detects the relationship between Parent and Child as `Child }o--|| Parent`.
In output ER diagram as above, parent-child relationship appears to be reversed.
So I need reverse these relationship descriptions now.

Thanks for publish wonderful package! 🙏
D.Shirakawa