### PR TITLE
Escape table names in foreign key

### DIFF
--- a/src/builder/uml-builder.class.ts
+++ b/src/builder/uml-builder.class.ts
@@ -146,7 +146,7 @@ export class UmlBuilder {
 			relationship = '||';
 		}
 
-		return `${ foreignKey.referencedTablePath } ||--${ relationship } ${ entity.tableNameWithoutPrefix }\n`;
+		return `"${ foreignKey.referencedTablePath }" ||--${ relationship } "${ entity.tableNameWithoutPrefix }"\n`;
 	}
 
 	/**


### PR DESCRIPTION
We used hypenated table names in our company and those throw syntax errors on the plantUML server. I escaped them for the relations/foreign keys.