### PR TITLE
Add optional chaining to relationMetadata

### DIFF
--- a/src/builder/uml-builder.class.ts
+++ b/src/builder/uml-builder.class.ts
@@ -142,7 +142,7 @@ export class UmlBuilder {
 		const oneOrMore = '|{';
 
 		let relationship = columns.some( ( column ) => !column.isNullable ) ? oneOrMore : zeroOrMore;
-		if ( columns.length === 1 && columns[0].relationMetadata.isOneToOne ) {
+		if ( columns.length === 1 && columns[0].relationMetadata?.isOneToOne ) {
 			relationship = '||';
 		}
 


### PR DESCRIPTION
An error can occur when relationMetadata becomes undefined. So, I added optional chaining accessing.